### PR TITLE
Removing unneeded dep on psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "suggest": {
         "psr/http-message": "The package containing the PSR-7 interfaces"
-    }
+    },
     "autoload": {
         "psr-4": {
             "Fig\\Http\\Message\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,11 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "psr/http-message": "^1.0"
+        "php": "^5.3 || ^7.0"
     },
+    "suggest": {
+        "psr/http-message": "The package containing the PSR-7 interfaces"
+    }
     "autoload": {
         "psr-4": {
             "Fig\\Http\\Message\\": "src/"


### PR DESCRIPTION
As suggested in #13, we can remove this dep (and move it as a suggestion) to the PSR-7 package, since we do not use it directly.