### PR TITLE
Emojis as the new norm for status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.2 - 2019-03-31
+
+### Added
+
+- [#11](https://github.com/php-fig/http-message-util/pull/11) Emoji status codes.
+
+### Changed
+
+- All status codes are now their correct emoji counterparts.
+
+### Deprecated
+
+- Numbers as they should no longer be standard.
+
+### Removed
+
+- All references to status code numbers.
+
+### Fixed
+
+- Everything.
+
 ## 1.1.3 - 2018-11-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.2 - 2019-03-31
+## 1️⃣.2️⃣ - 2️⃣0️⃣1️⃣9️⃣-0️⃣3️⃣-3️⃣1️⃣
 
 ### Added
 
-- [#11](https://github.com/php-fig/http-message-util/pull/11) Emoji status codes.
+- [#1️⃣6️⃣](https://github.com/php-fig/http-message-util/pull/16) Emoji status codes; 💯
 
 ### Changed
 

--- a/src/StatusCodeInterface.php
+++ b/src/StatusCodeInterface.php
@@ -82,6 +82,7 @@ interface StatusCodeInterface
     const 🍽️ = 416;
     const 😐 = 417;
     const 🤓 = 418;
+    const 🤗 = 420;
     const ✨ = 421;
     const 🤒 = 422;
     const 🔒 = 423;

--- a/src/StatusCodeInterface.php
+++ b/src/StatusCodeInterface.php
@@ -28,7 +28,7 @@ namespace Fig\Http\Message;
  * <code>
  * class ResponseFactory implements StatusCodeInterface
  * {
- *     public function createResponse($code = self::STATUS_OK)
+ *     public function createResponse($= self::STATUS_OK)
  *     {
  *     }
  * }
@@ -37,71 +37,71 @@ namespace Fig\Http\Message;
 interface StatusCodeInterface
 {
     // Informational 1xx
-    const STATUS_CONTINUE = 100;
-    const STATUS_SWITCHING_PROTOCOLS = 101;
-    const STATUS_PROCESSING = 102;
-    const STATUS_EARLY_HINTS = 103;
+    const 💯 = 100;
+    const 🔀 = 101;
+    const 🤔 = 102;
+    const 💭 = 103;
     // Successful 2xx
-    const STATUS_OK = 200;
-    const STATUS_CREATED = 201;
-    const STATUS_ACCEPTED = 202;
-    const STATUS_NON_AUTHORITATIVE_INFORMATION = 203;
-    const STATUS_NO_CONTENT = 204;
-    const STATUS_RESET_CONTENT = 205;
-    const STATUS_PARTIAL_CONTENT = 206;
-    const STATUS_MULTI_STATUS = 207;
-    const STATUS_ALREADY_REPORTED = 208;
-    const STATUS_IM_USED = 226;
+    const 👌 = 200;
+    const ✍️ = 201;
+    const ✔️ = 202;
+    const 📝 = 203;
+    const 🗅 = 204;
+    const 👍 = 205;
+    const 😩 = 206;
+    const 🤯 = 207;
+    const 📰 = 208;
+    const 💬 = 226;
     // Redirection 3xx
-    const STATUS_MULTIPLE_CHOICES = 300;
-    const STATUS_MOVED_PERMANENTLY = 301;
-    const STATUS_FOUND = 302;
-    const STATUS_SEE_OTHER = 303;
-    const STATUS_NOT_MODIFIED = 304;
-    const STATUS_USE_PROXY = 305;
-    const STATUS_RESERVED = 306;
-    const STATUS_TEMPORARY_REDIRECT = 307;
-    const STATUS_PERMANENT_REDIRECT = 308;
+    const 🔁 = 300;
+    const 🔂 = 301;
+    const 🔎 = 302;
+    const 😕 = 303;
+    const 😟 = 304;
+    const 😨 = 305;
+    const 🏚️ = 306;
+    const 🙃 = 307;
+    const 😬 = 308;
     // Client Errors 4xx
-    const STATUS_BAD_REQUEST = 400;
-    const STATUS_UNAUTHORIZED = 401;
-    const STATUS_PAYMENT_REQUIRED = 402;
-    const STATUS_FORBIDDEN = 403;
-    const STATUS_NOT_FOUND = 404;
-    const STATUS_METHOD_NOT_ALLOWED = 405;
-    const STATUS_NOT_ACCEPTABLE = 406;
-    const STATUS_PROXY_AUTHENTICATION_REQUIRED = 407;
-    const STATUS_REQUEST_TIMEOUT = 408;
-    const STATUS_CONFLICT = 409;
-    const STATUS_GONE = 410;
-    const STATUS_LENGTH_REQUIRED = 411;
-    const STATUS_PRECONDITION_FAILED = 412;
-    const STATUS_PAYLOAD_TOO_LARGE = 413;
-    const STATUS_URI_TOO_LONG = 414;
-    const STATUS_UNSUPPORTED_MEDIA_TYPE = 415;
-    const STATUS_RANGE_NOT_SATISFIABLE = 416;
-    const STATUS_EXPECTATION_FAILED = 417;
-    const STATUS_IM_A_TEAPOT = 418;
-    const STATUS_MISDIRECTED_REQUEST = 421;
-    const STATUS_UNPROCESSABLE_ENTITY = 422;
-    const STATUS_LOCKED = 423;
-    const STATUS_FAILED_DEPENDENCY = 424;
-    const STATUS_TOO_EARLY = 425;
-    const STATUS_UPGRADE_REQUIRED = 426;
-    const STATUS_PRECONDITION_REQUIRED = 428;
-    const STATUS_TOO_MANY_REQUESTS = 429;
-    const STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
-    const STATUS_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
+    const 👎 = 400;
+    const 🔐 = 401;
+    const 💳 = 402;
+    const 🛑 = 403;
+    const 🚧 = 404;
+    const 🙅 = 405;
+    const 🚫 = 406;
+    const 🛂 = 407;
+    const ⌛ = 408;
+    const 😠 = 409;
+    const 👋 = 410;
+    const 📏 = 411;
+    const ❌ = 412;
+    const 💣 = 413;
+    const 🤐 = 414;
+    const 💔 = 415;
+    const 🍽️ = 416;
+    const 😐 = 417;
+    const 🤓 = 418;
+    const ✨ = 421;
+    const 🤒 = 422;
+    const 🔒 = 423;
+    const 😭 = 424;
+    const 😴 = 425;
+    const 😷 = 426;
+    const 😱 = 428;
+    const 🙌 = 429;
+    const 😵 = 431;
+    const ⚖️ = 451;
     // Server Errors 5xx
-    const STATUS_INTERNAL_SERVER_ERROR = 500;
-    const STATUS_NOT_IMPLEMENTED = 501;
-    const STATUS_BAD_GATEWAY = 502;
-    const STATUS_SERVICE_UNAVAILABLE = 503;
-    const STATUS_GATEWAY_TIMEOUT = 504;
-    const STATUS_VERSION_NOT_SUPPORTED = 505;
-    const STATUS_VARIANT_ALSO_NEGOTIATES = 506;
-    const STATUS_INSUFFICIENT_STORAGE = 507;
-    const STATUS_LOOP_DETECTED = 508;
-    const STATUS_NOT_EXTENDED = 510;
-    const STATUS_NETWORK_AUTHENTICATION_REQUIRED = 511;
+    const 💩 = 500;
+    const 👷 = 501;
+    const ⛔ = 502;
+    const 🚷 = 503;
+    const ⏰ = 504;
+    const 🚪 = 505;
+    const ♻️ = 506;
+    const 🗑️ = 507;
+    const ➰ = 508;
+    const 📦 = 510;
+    const 🔏 = 511;
 }


### PR DESCRIPTION
In light of recent revelations that have occurred within the last week ending around the start of the month of April; emojis have become the new standard for status codes. Emojis have the ability to convey the proper emotions attributed to how we see the status codes without having people remember what the particular number means. This is also helpful to end users because no longer will we get calls that a user is getting repeated 404. Instead, now they can call you and say they are getting the construction emoji and they fully understand what means. 