### PR TITLE
Declare compatibility with PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^5.3 || ^7.0 || ^8.0"
     },
     "suggest": {
         "psr/http-message": "The package containing the PSR-7 interfaces"


### PR DESCRIPTION
I don't see why this package should not be declared as compatible with PHP 8.